### PR TITLE
Limpa cookie de sessão ao utilizar sessão expirada

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -15,11 +15,12 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-  if (
-    error instanceof ValidationError ||
-    error instanceof NotFoundError ||
-    error instanceof UnauthorizedError
-  ) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return response.status(error.statusCode).json(error);
+  }
+
+  if (error instanceof UnauthorizedError) {
+    clearSessionCookie(response);
     return response.status(error.statusCode).json(error);
   }
 
@@ -43,12 +44,24 @@ async function setSessionCookie(sessionToken, response) {
   response.setHeader("Set-Cookie", setCookie);
 }
 
+async function clearSessionCookie(response) {
+  const setCookie = cookie.serialize("session_id", "invalid", {
+    path: "/",
+    maxAge: -1,
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+  });
+
+  response.setHeader("Set-Cookie", setCookie);
+}
+
 const controller = {
   errorHandlers: {
     onNoMatch: onNoMatchHandler,
     onError: onErrorHandler,
   },
   setSessionCookie,
+  clearSessionCookie,
 };
 
 export default controller;

--- a/models/session.js
+++ b/models/session.js
@@ -63,7 +63,7 @@ async function create(userId) {
 async function renew(sessionId) {
   const expiresAt = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS);
 
-  const renewedSessionObject = runUpdateQuery(sessionId, expiresAt);
+  const renewedSessionObject = await runUpdateQuery(sessionId, expiresAt);
   return renewedSessionObject;
 
   async function runUpdateQuery(sessionId, expiresAt) {

--- a/models/session.js
+++ b/models/session.js
@@ -27,7 +27,7 @@ async function findOneValidByToken(sessionToken) {
 
     if (results.rowCount === 0) {
       throw new UnauthorizedError({
-        message: "Usuário não possui sess~ao ativa.",
+        message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
       });
     }
@@ -86,10 +86,35 @@ async function renew(sessionId) {
   }
 }
 
+async function expireById(sessionId) {
+  const expiredSessionObject = await runUpdateQuery(sessionId);
+  return expiredSessionObject;
+
+  async function runUpdateQuery(sessionId) {
+    const results = await database.query({
+      text: `
+        UPDATE
+          sessions
+        SET
+          expires_at = expires_at - interval '1 year',
+          updated_at = NOW()
+        WHERE
+          id = $1
+        RETURNING
+          *
+        ;`,
+      values: [sessionId],
+    });
+
+    return results.rows[0];
+  }
+}
+
 const session = {
   create,
   findOneValidByToken,
   renew,
+  expireById,
   EXPIRATION_IN_MILLISECONDS,
 };
 

--- a/pages/api/v1/sessions/index.js
+++ b/pages/api/v1/sessions/index.js
@@ -6,6 +6,7 @@ import session from "models/session.js";
 const router = createRouter();
 
 router.post(postHandler);
+router.delete(deleteHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -22,4 +23,14 @@ async function postHandler(request, response) {
   controller.setSessionCookie(newSession.token, response);
 
   return response.status(201).json(newSession);
+}
+
+async function deleteHandler(request, response) {
+  const sessionToken = request.cookies.session_id;
+
+  const sessionObject = await session.findOneValidByToken(sessionToken);
+  const expiredSession = await session.expireById(sessionObject.id);
+  controller.clearSessionCookie(response);
+
+  return response.status(200).json(expiredSession);
 }

--- a/tests/integration/api/v1/user/delete.test.js
+++ b/tests/integration/api/v1/user/delete.test.js
@@ -1,0 +1,141 @@
+import { version as uuidversion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+import orchestrator from "tests/orchestrator.js";
+import session from "models/session.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("DELETE /api/v1/user", () => {
+  describe("Default user", () => {
+    test("With nonexistent session", async () => {
+      const nonexistentToken =
+        "8d8232e5ea2f7c400469934ef858abec77172f8446ced11c2effc4e11ca04c0a05b188bffe8e1b5fe1321990a47b2bca";
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          cookie: `session_id=${nonexistentToken}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.EXPIRATION_IN_MILLISECONDS),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "userWithExpiredSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With valid session", async () => {
+      const createdUser = await orchestrator.createUser();
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: sessionObject.id,
+        token: sessionObject.token,
+        user_id: sessionObject.user_id,
+        expires_at: responseBody.expires_at,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidversion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(
+        responseBody.expires_at < sessionObject.expires_at.toISOString()
+      ).toEqual(true);
+      expect(
+        responseBody.updated_at > sessionObject.updated_at.toISOString()
+      ).toEqual(true);
+
+      //Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
+
+      // Double check assertions
+      const doubleCheckResponse = await fetch(
+        "http://localhost:3000/api/v1/user",
+        {
+          headers: {
+            Cookie: `session_id=${sessionObject.token}`,
+          },
+        }
+      );
+
+      expect(doubleCheckResponse.status).toBe(401);
+
+      const doubleCheckResponseBody = await doubleCheckResponse.json();
+
+      expect(doubleCheckResponseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -88,9 +88,22 @@ describe("GET /api/v1/users/user", () => {
 
       expect(responseBody).toEqual({
         name: "UnauthorizedError",
-        message: "Usuário não possui sess~ao ativa.",
+        message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
+      });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
       });
     });
 
@@ -119,9 +132,22 @@ describe("GET /api/v1/users/user", () => {
 
       expect(responseBody).toEqual({
         name: "UnauthorizedError",
-        message: "Usuário não possui sess~ao ativa.",
+        message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
+      });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
       });
     });
   });


### PR DESCRIPTION
Este Pull Request é composto por dois commits:

https://github.com/filipedeschamps/clone-tabnews/commit/a315bdf2f3f86012e0f50f12cde3961915275914
Este commit, dentro do `controller.js` na parte onde ele recebe os erros (`onErrorHandler`), separa em sua própria condicional o que é um `UnauthorizedError` para que neste caso seja devolvido um cabeçalho Set-Cookie com o objetivo de limpar o `session_id` do client.

https://github.com/filipedeschamps/clone-tabnews/commit/ccaf6235f0020ac0a7e71e8a71651c687e71d902
Este commit adiciona a falta de um `await` dentro do `session.renew()`